### PR TITLE
Added a clear ContextContent

### DIFF
--- a/context_engine/context_engine/models.py
+++ b/context_engine/context_engine/models.py
@@ -2,12 +2,17 @@ from typing import List
 
 from pydantic import BaseModel
 
+from context_engine.models.data_models import ContextContent
+
 
 class ContextSnippet(BaseModel):
     reference: str
     text: str
 
 
-class ContextQueryResult(BaseModel):
+class ContextQueryResult(ContextContent):
     query: str
     snippets: List[ContextSnippet]
+
+    def to_text(self):
+        return self.json()

--- a/context_engine/models/data_models.py
+++ b/context_engine/models/data_models.py
@@ -1,4 +1,5 @@
-from typing import Optional, List, Union, Iterable, Dict
+from abc import ABC, abstractmethod
+from typing import Optional, List, Union, Dict, Sequence
 
 from pydantic import BaseModel, Field
 
@@ -19,8 +20,17 @@ class Document(BaseModel):
     metadata: Metadata
 
 
+class ContextContent(BaseModel, ABC):
+
+    # Any context should be able to be represented as well formatted text.
+    # In the most minimal case, that could simply be a call to `.json()`.
+    @abstractmethod
+    def to_text(self) -> str:
+        pass
+
+
 class Context(BaseModel):
-    content: Union[str, BaseModel, Iterable[BaseModel]]
+    content: Union[ContextContent, Sequence[ContextContent]]
     num_tokens: int = Field(exclude=True)
     debug_info: dict = Field(default_factory=dict, exclude=True)
 


### PR DESCRIPTION
This way we communicate exactly what a `Context` is - something that can be expressed as nicely formatted text