### PR TITLE
[CI] Cancel ongoing CI runs if a new push to the same branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,13 @@ name: CI
 
 on: pull_request
 
+# Cancel previous runs on the same branch \ PR number if they are still running
+# From: https://stackoverflow.com/a/72408109
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   run-linters:
     name: Run linters


### PR DESCRIPTION
When a new commit is pushed to a PR - cancel already-running CI jobs to the same branch

## Type of Change

- [X] Infrastructure change (CI configs, etc)