### PR TITLE
CLI - added option not to stop on the first error during upsert

### DIFF
--- a/src/resin_cli/cli.py
+++ b/src/resin_cli/cli.py
@@ -52,7 +52,10 @@ def check_service_health(url: str):
         raise CLIError(msg)
 
     except requests.exceptions.HTTPError as e:
-        error = e.response.json().get("detail", None) or e.response.text
+        if e.response is not None:
+            error = e.response.json().get("detail", None) or e.response.text
+        else:
+            error = str(e)
         msg = (
             f"Resin service on {url} is not healthy, failed with error: {error}"
         )


### PR DESCRIPTION
## Solution

Now that we're upserting in batches anyway, it makes more sense to allow the user to ignore errors and continue to upsert other documents

## Type of Change

- [X] New feature (non-breaking change which adds functionality)