### PR TITLE
[cli] Bug fix - close pbar properly

### DIFF
--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -297,6 +297,7 @@ def upsert(index_name: str,
                 raise CLIError(msg)
 
         pbar.update(len(batch))
+    pbar.close()
 
     if failed_docs:
         msg = (


### PR DESCRIPTION
## Problem
![image](https://github.com/pinecone-io/canopy/assets/118673156/30288a07-6986-412c-b180-d1de723b877c)

## Solution

Fixes the redundant `tqdm` pbar that appears after "success"

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
