### PR TITLE
change defaults

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -46,7 +46,7 @@ chat_engine:
         type: OpenAIRecordEncoder
         params:
           model_name: text-embedding-ada-002
-          batch_size: 100
+          batch_size: 400
 
       chunker:
         type: MarkdownChunker

--- a/src/canopy/knowledge_base/knowledge_base.py
+++ b/src/canopy/knowledge_base/knowledge_base.py
@@ -490,7 +490,7 @@ class KnowledgeBase(BaseKnowledgeBase):
     def upsert(self,
                documents: List[Document],
                namespace: str = "",
-               batch_size: int = 100,
+               batch_size: int = 200,
                show_progress_bar: bool = False):
         """
         Upsert documents into the knowledge base.

--- a/src/canopy/knowledge_base/record_encoder/openai.py
+++ b/src/canopy/knowledge_base/record_encoder/openai.py
@@ -17,7 +17,7 @@ class OpenAIRecordEncoder(DenseRecordEncoder):
     def __init__(self,
                  *,
                  model_name: str = "text-embedding-ada-002",
-                 batch_size: int = 100,
+                 batch_size: int = 400,
                  **kwargs):
         encoder = OpenAIEncoder(model_name)
         super().__init__(dense_encoder=encoder, batch_size=batch_size, **kwargs)

--- a/src/canopy_server/api_models.py
+++ b/src/canopy_server/api_models.py
@@ -19,7 +19,7 @@ class ContextQueryRequest(BaseModel):
 
 class ContextUpsertRequest(BaseModel):
     documents: List[Document]
-    batch_size: int = 100
+    batch_size: int = 200
 
 
 class ContextDeleteRequest(BaseModel):


### PR DESCRIPTION
## Problem

Current defaults for OpenAI embeddings and Pinecone batch upsert are sub-optimal

## Solution

Increase defaults to meet free tier limitations of OpenAI and Pinecone

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Same tests apply. I run it manually with some arxiv data
