### PR TITLE
batch upsert by chunks in cli

### DIFF
--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -1,7 +1,7 @@
 import os
 import signal
 import subprocess
-from typing import Dict, Any, Optional, List, Iterator
+from typing import Dict, Any, Optional, List, Iterable
 
 import click
 import time
@@ -193,7 +193,7 @@ def new(index_name: str, config: Optional[str]):
 
 def _batch_documents_by_chunks(chunker: Chunker,
                                documents: List[Document],
-                               batch_size: int = 400) -> Iterator[List[Document]]:
+                               batch_size: int = 400) -> Iterable[List[Document]]:
     """
     Note: this is a temporary solution until we improve the upsert pipeline.
           using the chunker directly is not recommended, especially since the knowledge base also going to use it internally on the same documents.


### PR DESCRIPTION
## Problem

batch upsert should be determined by the number of chunks and not number of documents for large upsert

## Solution

For now we will batch by number of chunks only in the CLI. Later we will refactor the whole upsert pipeline

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Manual tests with short documents dataset, and with long documents dataset
