### PR TITLE
[CI] Release workflow bug fix - wrong package name

### DIFF
--- a/.github/workflows/pre-release-CI.yml
+++ b/.github/workflows/pre-release-CI.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           source $VENV
           ls -lah ./dist
-          pip install ./dist/pinecone_canopy*.whl
+          pip install ./dist/canopy_sdk*.whl
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/pre-release-CI.yml
+++ b/.github/workflows/pre-release-CI.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Install the wheel
         run: |
           source $VENV
-          pip install dist/pinecone_canopy*.whl
+          ls -lah ./dist
+          pip install ./dist/pinecone_canopy*.whl
 
       - name: Run unit tests
         run: |


### PR DESCRIPTION
## Problem

`Release` CI workflow was broken

## Solution

The release workflow had a step that still accidentally used the old name - `pinecone-canopy`.

## Type of Change

- [X] Infrastructure change (CI configs, etc)

## Test Plan

Tested manually: The workflow is now [working](https://github.com/pinecone-io/canopy/actions/runs/6774830668)
<img width="1056" alt="image" src="https://github.com/pinecone-io/canopy/assets/118673156/06bf6447-015f-4c6a-84d7-43099d6a8d26">
