### PR TITLE
Improve test_list_indexes() - don't depend on actual list

### DIFF
--- a/tests/system/knowledge_base/test_knowledge_base.py
+++ b/tests/system/knowledge_base/test_knowledge_base.py
@@ -232,7 +232,7 @@ def test_list_indexes(index_full_name):
     assert len(index_list) > 0
     for item in index_list:
         assert INDEX_NAME_PREFIX in item
-    
+
     assert index_full_name in index_list
 
 

--- a/tests/system/knowledge_base/test_knowledge_base.py
+++ b/tests/system/knowledge_base/test_knowledge_base.py
@@ -227,12 +227,13 @@ def test_create_index(index_full_name, knowledge_base):
 
 
 def test_list_indexes(index_full_name):
-    actual = list_canopy_indexes()
-    expected = [index for index in pinecone.list_indexes()
-                if index.startswith(INDEX_NAME_PREFIX)]
+    index_list = list_canopy_indexes()
 
-    assert index_full_name in actual
-    assert sorted(actual) == sorted(expected)
+    assert len(index_list) > 0
+    for item in index_list:
+        assert INDEX_NAME_PREFIX in item
+    
+    assert index_full_name in index_list
 
 
 def test_is_verify_index_connection_happy_path(knowledge_base):


### PR DESCRIPTION
## Problem

Test was flaky and sometimes [fails](https://github.com/pinecone-io/canopy/actions/runs/6776632806/job/18418637956#step:7:123).  
The current implementation depended on the list being exactly the same between two calls to the underlying `pinecone.list_index()`. As indexes are being added and deleted by other CI runs, this isn't guaranteed. 
## Solution
Changed the test to simply verify that the list only contains items with the `canopy--` prefix, and that the index created by the current CI run is included in the list

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
