### PR TITLE
Adding support for .txt files in `canopy upsert`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ cython_debug/
 
 datafiles/*
 canopy-api-docs.html
+.vscode/

--- a/README.md
+++ b/README.md
@@ -116,9 +116,14 @@ canopy upsert /path/to/data_directory/file.parquet
 
 # or
 canopy upsert /path/to/data_directory/file.jsonl
+
+# or
+canopy upsert /path/to/directory_of_txt_files/
+
+# ...
 ```
 
-Canopy supports files in `jsonl` or `parquet` formats. The documents should have the following schema:
+Canopy supports files in `jsonl`, `parquet` and `csv` formats. The documents should have the following schema:
 
 ```
 +----------+--------------+--------------+---------------+
@@ -129,6 +134,8 @@ Canopy supports files in `jsonl` or `parquet` formats. The documents should have
 +----------+--------------+--------------+---------------+
 ```
 > [This notebook](https://colab.research.google.com/github/pinecone-io/examples/blob/master/learn/generation/canopy/00-canopy-data-prep.ipynb) shows how you create a dataset in this format.
+
+Additionally, you can load plaintext data files in `.txt` format. In this case, each file will be treated as a single document. The document id will be the filename, and the source will be the full path of the file.
 
 Follow the instructions in the CLI to upload your data.
 

--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -310,7 +310,8 @@ def upsert(index_name: str,
         except Exception:
             msg = (
                 f"A unexpected error while loading the data from files in {data_path}. "
-                "Please make sure the data is in valid `jsonl` or `parquet` format."
+                "Please make sure the data is in valid `jsonl`, `parquet`, `csv` format "
+                "or plaintext `.txt` files."
             )
             raise CLIError(msg)
         pd.options.display.max_colwidth = 20

--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -310,8 +310,8 @@ def upsert(index_name: str,
         except Exception:
             msg = (
                 f"A unexpected error while loading the data from files in {data_path}. "
-                "Please make sure the data is in valid `jsonl`, `parquet`, `csv` format "
-                "or plaintext `.txt` files."
+                "Please make sure the data is in valid `jsonl`, `parquet`, `csv` format"
+                " or plaintext `.txt` files."
             )
             raise CLIError(msg)
         pd.options.display.max_colwidth = 20

--- a/src/canopy_cli/data_loader/data_loader.py
+++ b/src/canopy_cli/data_loader/data_loader.py
@@ -87,7 +87,6 @@ def _load_multiple_txt_files(file_paths: List[str]) -> pd.DataFrame:
     if len(file_paths) == 0:
         raise ValueError("file_paths must not be empty")
 
-    df = pd.DataFrame(columns=["id", "text", "source"])
     rows = []
     for file_path in file_paths:
         with open(file_path, "r") as f:

--- a/src/canopy_cli/data_loader/data_loader.py
+++ b/src/canopy_cli/data_loader/data_loader.py
@@ -76,7 +76,7 @@ def _load_multiple_txt_files(file_paths: List[str]) -> pd.DataFrame:
     """Load multiple text files into a single dataframe
 
     Args:
-        file_paths (List[str]): List of file paths to load
+        file_paths: List of file paths to load
 
     Returns:
         pd.DataFrame: Dataframe with columns `id`, `text` and 'source`
@@ -135,6 +135,15 @@ def _load_multiple_non_schematic_files(
 
 
 def load_from_path(path: str) -> List[Document]:
+    """
+    Load documents from a file or directory
+
+    Args:
+        path: Path to file or directory
+
+    Returns:
+        List[Document]: List of documents
+    """
     if os.path.isdir(path):
         # List all files in directory
         all_files_schematic = [f for ext in ['*.jsonl', '*.parquet', '*.csv']

--- a/src/canopy_cli/data_loader/data_loader.py
+++ b/src/canopy_cli/data_loader/data_loader.py
@@ -159,10 +159,11 @@ def load_from_path(path: str) -> List[Document]:
             documents.extend(_load_single_schematic_file_by_suffix(f))
 
         # Load all non-schematic files
-        documents.extend(
-            _load_multiple_non_schematic_files(
-                all_files_non_schematic_txt,
-                NonSchematicFilesTypes.TEXT))
+        if len(all_files_non_schematic_txt) > 0:
+            documents.extend(
+                _load_multiple_non_schematic_files(
+                    all_files_non_schematic_txt,
+                    NonSchematicFilesTypes.TEXT))
 
     # Load single file
     elif os.path.isfile(path):

--- a/tests/unit/cli/test_data_loader.py
+++ b/tests/unit/cli/test_data_loader.py
@@ -8,7 +8,7 @@ from canopy_cli.data_loader.data_loader import (
     IDsNotUniqueError,
     DocumentsValidationError,
     load_from_path,
-    _load_single_file_by_suffix, _df_to_documents,
+    _load_single_schematic_file_by_suffix, _df_to_documents,
 )
 
 
@@ -253,7 +253,7 @@ def test_load_single_file_jsonl(tmpdir, dict_rows_input, expected_documents):
     path = tmpdir.join("test.jsonl")
     path.write("\n".join([json.dumps(row) for row in dict_rows_input]))
 
-    docs = _load_single_file_by_suffix(str(path))
+    docs = _load_single_schematic_file_by_suffix(str(path))
     assert docs == expected_documents
 
 
@@ -263,7 +263,7 @@ def test_load_single_file_parquet(tmpdir, dict_rows_input, expected_documents):
     path = tmpdir.join("test.parquet")
     pd.DataFrame(data).to_parquet(str(path))
 
-    docs = _load_single_file_by_suffix(str(path))
+    docs = _load_single_schematic_file_by_suffix(str(path))
     assert docs == expected_documents
 
 


### PR DESCRIPTION
## Problem

today canopy supports only structured file types s.a. `jsonl`, `parquet` and `csv`
we want to enable people to load `.txt` files directly.

## Solution

- Canopy will look for txt files in the directory
- Canopy will assign the filename as `id` and the full path as `source`, where the `text` field will be the content
- There will be no metadata added to the txt files

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Manually tested 
- reading 2 text files in directory
- reading 2 text files + parquet file (appends all)
- trying to read non supported type (fails)
