### PR TITLE
update incorrect pinecone quick start pathname

### DIFF
--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -80,7 +80,7 @@ def validate_connection():
             f"{str(e)}\n"
             "Credentials should be set by the PINECONE_API_KEY and PINECONE_ENVIRONMENT"
             " environment variables. "
-            "Please visit https://www.pinecone.io/docs/quick-start/ for more details."
+            "Please visit https://www.pinecone.io/docs/quickstart/ for more details."
         )
         raise CLIError(msg)
     try:
@@ -284,7 +284,7 @@ def upsert(index_name: str,
         if "credentials" in msg:
             msg += ("\nCredentials should be set by the PINECONE_API_KEY and "
                     "PINECONE_ENVIRONMENT environment variables. Please visit "
-                    "https://www.pinecone.io/docs/quick-start/ for more details.")
+                    "https://www.pinecone.io/docs/quickstart/ for more details.")
         raise CLIError(msg)
 
     click.echo("Canopy is going to upsert data from ", nl=False)


### PR DESCRIPTION
## Problem

Describe the purpose of this change. What problem is being solved and why?

The quick start link reference in the debug output led to a 404 page

## Solution

Found the right page, _I think_:  https://docs.pinecone.io/docs/quickstart

## Type of Change

- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Run canopy command without specifying the environment variable.
