### PR TITLE
CLI and server bug fixes on Windows

### DIFF
--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -488,7 +488,7 @@ def chat(chat_server_url, rag, debug, stream):
             history=history_with_pinecone,
             message=message,
             stream=stream,
-            api_base=os.path.join(urljoin(url, "/context")),
+            api_base=os.path.join(urljoin(chat_server_url, "/context")),
             print_debug_info=debug,
         )
 
@@ -549,7 +549,7 @@ def start(host: str, port: str, reload: bool,
         "gunicorn canopy_server.app:app --worker-class uvicorn.workers.UvicornWorker "
         f"--bind {host}:{port} --workers <num_workers>"
     ) if os.name != "nt" else (
-        "please use Docker"  #  TODO: Add Docker instructions once we have a Dockerfile
+        "please use Docker"  # TODO: Add Docker instructions once we have a Dockerfile
     )
     for c in note_msg + msg_suffix:
         click.echo(click.style(c, fg="red"), nl=False)

--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -171,8 +171,8 @@ def cli(ctx):
 
 
 @cli.command(help="Check if canopy server is running and healthy.")
-@click.option("--url", default="http://0.0.0.0:8000",
-              help="Canopy's server url. Defaults to http://0.0.0.0:8000")
+@click.option("--url", default="http://localhost:8000",
+              help="Canopy's server url. Defaults to http://localhost:8000")
 def health(url):
     check_server_health(url)
     click.echo(click.style("Canopy server is healthy!", fg="green"))
@@ -432,8 +432,8 @@ def _chat(
               help="Print additional debugging information")
 @click.option("--rag/--no-rag", default=True,
               help="Compare RAG-infused Chatbot with vanilla LLM",)
-@click.option("--chat-server-url", default="http://0.0.0.0:8000",
-              help="URL of the Canopy server to use. Defaults to http://0.0.0.0:8000")
+@click.option("--chat-server-url", default="http://localhost:8000",
+              help="URL of the Canopy server to use. Defaults to http://localhost:8000")
 def chat(chat_server_url, rag, debug, stream):
     check_server_health(chat_server_url)
     note_msg = (
@@ -579,8 +579,8 @@ def start(host: str, port: str, reload: bool,
         """
     )
 )
-@click.option("url", "--url", default="http://0.0.0.0:8000",
-              help="URL of the Canopy server to use. Defaults to http://0.0.0.0:8000")
+@click.option("url", "--url", default="http://localhost:8000",
+              help="URL of the Canopy server to use. Defaults to http://localhost:8000")
 def stop(url):
     if os.name != "nt":
         # Check if the server was started using Gunicorn
@@ -625,8 +625,8 @@ def stop(url):
         """
     )
 )
-@click.option("--url", default="http://0.0.0.0:8000",
-              help="Canopy's server url. Defaults to http://0.0.0.0:8000")
+@click.option("--url", default="http://localhost:8000",
+              help="Canopy's server url. Defaults to http://localhost:8000")
 def api_docs(url):
     import webbrowser
 

--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -488,7 +488,7 @@ def chat(chat_server_url, rag, debug, stream):
             history=history_with_pinecone,
             message=message,
             stream=stream,
-            api_base=os.path.join(urljoin(chat_server_url, "/context")),
+            api_base=urljoin(chat_server_url, "/context"),
             print_debug_info=debug,
         )
 
@@ -549,7 +549,7 @@ def start(host: str, port: str, reload: bool,
         "gunicorn canopy_server.app:app --worker-class uvicorn.workers.UvicornWorker "
         f"--bind {host}:{port} --workers <num_workers>"
     ) if os.name != "nt" else (
-        "please use Docker"  # TODO: Add Docker instructions once we have a Dockerfile
+        "please use Docker with a Gunicorn server."  # TODO: Add Docker instructions once we have a Dockerfile
     )
     for c in note_msg + msg_suffix:
         click.echo(click.style(c, fg="red"), nl=False)

--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -488,7 +488,7 @@ def chat(chat_server_url, rag, debug, stream):
             history=history_with_pinecone,
             message=message,
             stream=stream,
-            api_base=os.path.join(chat_server_url, "context"),
+            api_base=os.path.join(urljoin(url, "/context")),
             print_debug_info=debug,
         )
 

--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -549,7 +549,8 @@ def start(host: str, port: str, reload: bool,
         "gunicorn canopy_server.app:app --worker-class uvicorn.workers.UvicornWorker "
         f"--bind {host}:{port} --workers <num_workers>"
     ) if os.name != "nt" else (
-        "please use Docker with a Gunicorn server."  # TODO: Add Docker instructions once we have a Dockerfile
+        # TODO: Replace with proper instructions once we have a Dockerfile
+        "please use Docker with a Gunicorn server."
     )
     for c in note_msg + msg_suffix:
         click.echo(click.style(c, fg="red"), nl=False)

--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -541,12 +541,17 @@ def start(host: str, port: str, reload: bool,
           config: Optional[str], index_name: Optional[str]):
     note_msg = (
         "🚨 Note 🚨\n"
-        "For debugging only. To run the Canopy server in production, run the command:"
+        "For debugging only. To run the Canopy server in production "
+    )
+    msg_suffix = (
+        "run the command:"
         "\n"
         "gunicorn canopy_server.app:app --worker-class uvicorn.workers.UvicornWorker "
         f"--bind {host}:{port} --workers <num_workers>"
+    ) if os.name != "nt" else (
+        "please use Docker"  #  TODO: Add Docker instructions once we have a Dockerfile
     )
-    for c in note_msg:
+    for c in note_msg + msg_suffix:
         click.echo(click.style(c, fg="red"), nl=False)
         time.sleep(0.01)
     click.echo()

--- a/src/canopy_server/app.py
+++ b/src/canopy_server/app.py
@@ -255,7 +255,10 @@ async def shutdown() -> ShutdownResponse:
             status_code=500,
             detail="Failed to locate parent process. Cannot shutdown server.",
         )
-    kill_signal = signal.CTRL_C_EVENT if os.name == 'nt' else signal.SIGINT
+    if sys.platform == 'win32':
+        kill_signal = signal.CTRL_C_EVENT
+    else:
+        kill_signal = signal.SIGINT
     os.kill(pid, kill_signal)
     return ShutdownResponse()
 

--- a/src/canopy_server/app.py
+++ b/src/canopy_server/app.py
@@ -255,7 +255,8 @@ async def shutdown() -> ShutdownResponse:
             status_code=500,
             detail="Failed to locate parent process. Cannot shutdown server.",
         )
-    os.kill(pid, signal.SIGINT)
+    kill_signal = signal.CTRL_C_EVENT if os.name == 'nt' else signal.SIGINT
+    os.kill(pid, kill_signal)
     return ShutdownResponse()
 
 


### PR DESCRIPTION
## Problem

Fixes multiple bugs when running the CLI on windows:
1. On windows, calling CLI commands that use the server (e.g. `canopy chat`) didn't work. 
2. There was also a bug in inferring the `/chat` endpoint, which was using `os.path.join()`
3. `canopy stop` tried to `pgrep gunicorn`, even though Windows doesn't have a `pgrep` command and Gunicorn isn't supported on windows.
4. The `/shutdown` endpoint wasn't working correctly on Windows

Resolves #166. 

## Solution

- The CLI used the url `http://0.0.0.0:8000`/ by default, which is not supported on windows. I replaced it with `http://localhost:8000`.
- In windows we need to send the `CTRL_C` signal, which has a totally different implementation than `SIGINT`

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Tested manually on mac, Windows and Linux.  
We need to add a proper CLI unit test (known issue)