### PR TITLE
[CI] Release workflow - use dedicated token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.ref }}
+          token: ${{ secrets.VERSION_BUMP_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -80,6 +83,9 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.ref }}
+          token: ${{ secrets.VERSION_BUMP_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -122,7 +128,7 @@ jobs:
       - name: Create GH release
         uses: ncipollo/release-action@v1
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag: V${{ needs.build.outputs.new_version }}
           name: ${{ needs.build.outputs.new_version }}


### PR DESCRIPTION
## Problem

The `release` CI workflow was still unable to push version bumps to `main`
## Solution

I created a dedicated bot account with permissions to push to protected branches. The PAT of that bot is used for pushing the version bump to `main`

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Tested manually