### PR TITLE
Added release 0.2.0 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [0.2.0] - 2023-11-15
+
+### Bug fixes
+- Bug fix in E2E test that prevented running `pytest tests/` [#175](https://github.com/pinecone-io/canopy/pull/175)
+
+### Added
+- Upgrade openai client dependency to v.1.2.3 (required code change) [#171](https://github.com/pinecone-io/canopy/pull/171), [#178](https://github.com/pinecone-io/canopy/pull/178)
+
+### Breaking changes
+- Added versioning to Canopy server's API [#169](https://github.com/pinecone-io/canopy/pull/169)
+
+**Full Changelog**: https://github.com/pinecone-io/canopy/compare/V0.1.4...V0.2.0
 ## [0.1.4] - 2023-11-14
 
 ### Bug fixes


### PR DESCRIPTION
The version bump itself would happen in the release workflow, which is finally fixed!

(In the near future we will switch to automatic CHANGELOG)