### PR TITLE
CLI: read config file from env location (Issue #189)

### DIFF
--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -102,9 +102,7 @@ def _initialize_tokenizer():
 
 def _read_config_file(config_file: Optional[str]) -> Dict[str, Any]:
     if config_file is None:
-        config_file = os.getenv("CANOPY_CONFIG_FILE", None)
-        if config_file is None:
-            return {}
+        return {}
 
     try:
         with open(config_file, 'r') as f:
@@ -217,9 +215,10 @@ def health(url):
     )
 )
 @click.argument("index-name", nargs=1, envvar="INDEX_NAME", type=str, required=True)
-@click.option("--config", "-c", default=None,
-              help="Path to a canopy config file. Optional, otherwise configuration "
-                   "file specified in $CANOPY_CONFIG_FILE will be used.")
+@click.option("--config", "-c", default=None, envvar="CANOPY_CONFIG_FILE",
+              help="Path to a canopy config file. Can also be set by the "
+                   "`CANOPY_CONFIG_FILE` envrionment variable. Otherwise, the built-in"
+                   "defualt configuration will be used.")
 def new(index_name: str, config: Optional[str]):
     _initialize_tokenizer()
     kb_config = _load_kb_config(config)
@@ -282,9 +281,10 @@ def _batch_documents_by_chunks(chunker: Chunker,
                    "be uploaded. "
                    "When set to True, the upsert process will continue on failure, as "
                    "long as less than 10% of the documents have failed to be uploaded.")
-@click.option("--config", "-c", default=None,
-              help="Path to a canopy config file. Optional, otherwise configuration "
-                   "file specified in $CANOPY_CONFIG_FILE will be used.")
+@click.option("--config", "-c", default=None, envvar="CANOPY_CONFIG_FILE",
+              help="Path to a canopy config file. Can also be set by the "
+                   "`CANOPY_CONFIG_FILE` envrionment variable. Otherwise, the built-in"
+                   "defualt configuration will be used.")
 def upsert(index_name: str,
            data_path: str,
            allow_failures: bool,
@@ -563,9 +563,10 @@ def chat(chat_server_url, rag, debug, stream):
               help="TCP port to bind the server to. Defaults to 8000")
 @click.option("--reload/--no-reload", default=False,
               help="Set the server to reload on code changes. Defaults to False")
-@click.option("--config", "-c", default=None,
-              help="Path to a canopy config file. Optional, otherwise configuration "
-                   "file specified in $CANOPY_CONFIG_FILE will be used.")
+@click.option("--config", "-c", default=None, envvar="CANOPY_CONFIG_FILE",
+              help="Path to a canopy config file. Can also be set by the "
+                   "`CANOPY_CONFIG_FILE` envrionment variable. Otherwise, the built-in"
+                   "defualt configuration will be used.")
 @click.option("--index-name", default=None,
               help="Index name, if not provided already as an environment variable.")
 def start(host: str, port: str, reload: bool,

--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -102,7 +102,9 @@ def _initialize_tokenizer():
 
 def _read_config_file(config_file: Optional[str]) -> Dict[str, Any]:
     if config_file is None:
-        return {}
+        config_file = os.getenv("CANOPY_CONFIG_FILE", None)
+        if config_file is None:
+            return {}
 
     try:
         with open(config_file, 'r') as f:
@@ -214,7 +216,7 @@ def health(url):
 @click.argument("index-name", nargs=1, envvar="INDEX_NAME", type=str, required=True)
 @click.option("--config", "-c", default=None,
               help="Path to a canopy config file. Optional, otherwise configuration "
-                   "defaults will be used.")
+                   "file specified in $CANOPY_CONFIG_FILE will be used.")
 def new(index_name: str, config: Optional[str]):
     _initialize_tokenizer()
     kb_config = _load_kb_config(config)
@@ -279,7 +281,7 @@ def _batch_documents_by_chunks(chunker: Chunker,
                    "long as less than 10% of the documents have failed to be uploaded.")
 @click.option("--config", "-c", default=None,
               help="Path to a canopy config file. Optional, otherwise configuration "
-                   "defaults will be used.")
+                   "file specified in $CANOPY_CONFIG_FILE will be used.")
 def upsert(index_name: str,
            data_path: str,
            allow_failures: bool,
@@ -296,6 +298,7 @@ def upsert(index_name: str,
     _initialize_tokenizer()
 
     kb_config = _load_kb_config(config)
+    print(kb_config)
     try:
         kb = KnowledgeBase.from_config(kb_config, index_name=index_name)
     except openai.OpenAIError:
@@ -558,7 +561,7 @@ def chat(chat_server_url, rag, debug, stream):
               help="Set the server to reload on code changes. Defaults to False")
 @click.option("--config", "-c", default=None,
               help="Path to a canopy config file. Optional, otherwise configuration "
-                   "defaults will be used.")
+                   "file specified in $CANOPY_CONFIG_FILE will be used.")
 @click.option("--index-name", default=None,
               help="Index name, if not provided already in as an environment variable")
 def start(host: str, port: str, reload: bool,

--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -301,7 +301,6 @@ def upsert(index_name: str,
     _initialize_tokenizer()
 
     kb_config = _load_kb_config(config)
-    print(kb_config)
     try:
         kb = KnowledgeBase.from_config(kb_config, index_name=index_name)
     except openai.OpenAIError:


### PR DESCRIPTION
This PR fixes the bug described in issue #189.


## Problem

The issue occurs then the user runs a Canopy CLI command (such as `new`, `upsert`) and does not specify the `-c` parameter with a config file lcoation. 
The current behaviour is to default to an empty (default) configuration while the user might expect Canopy to read the config file location specified in the environment variable `CANOPY_CONFIG_FILE`.

## Solution

This change updates the way the config file is loaded by the Canopy CLI. When the config file location is not specified through the `-c` parameter, we use the file location specified in the environment variable CANOPY_COPY_FILE. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Only manual testing was done for this change. 
