### PR TITLE
Cleanup indexes in case of failure

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -96,7 +96,7 @@ jobs:
         echo "Test Run ID: ${run_id}"
         poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_e2e.html --self-contained-html tests/e2e
     - name: Cleanup indexes
-      if: cancelled() || failure() #&& github.event_name == 'merge_group'
+      if: cancelled() || failure() # && github.event_name == 'merge_group'
       env:
         PINECONE_ENVIRONMENT: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_ENVIRONMENT_3 || secrets.PINECONE_ENVIRONMENT_4 }}
         PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -96,14 +96,14 @@ jobs:
         echo "Test Run ID: ${run_id}"
         poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_e2e.html --self-contained-html tests/e2e
     - name: Cleanup indexes
-      if: cancelled() || failure() # && github.event_name == 'merge_group'
+      if: cancelled() || failure() #&& github.event_name == 'merge_group'
       env:
         PINECONE_ENVIRONMENT: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_ENVIRONMENT_3 || secrets.PINECONE_ENVIRONMENT_4 }}
         PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}
       run: |
         export PYTHONPATH=.
-        poetry run python scripts/cleanup_indexes.py "aaaaaa"
-        poetry run python scripts/cleanup_indexes.py "bbbbbb"
+        echo ${{ steps.e2e_tests.outputs.run_id }}
+        echo ${{ steps.system_tests.outputs.run_id }}
     - name: upload pytest report.html
       uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -102,8 +102,10 @@ jobs:
         PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}
       run: |
         export PYTHONPATH=.
-        poetry run python scripts/cleanup_indexes.py ${{ steps.e2e_tests.outputs.run_id }}
-        poetry run python scripts/cleanup_indexes.py ${{ steps.system_tests.outputs.run_id }}
+#        poetry run python scripts/cleanup_indexes.py ${{ steps.e2e_tests.outputs.run_id }}
+#        poetry run python scripts/cleanup_indexes.py ${{ steps.system_tests.outputs.run_id }}
+        poetry run python scripts/cleanup_indexes.py "aaaaaa"
+        poetry run python scripts/cleanup_indexes.py "bbbbbb"
     - name: upload pytest report.html
       uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -79,6 +79,7 @@ jobs:
         echo "run_id=${run_id}" >> $GITHUB_OUTPUT
         echo "Test Run ID: ${run_id}"
         poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_system.html --self-contained-html tests/system
+        exit 1
     - name: Run e2e tests
       id: e2e_tests
       if: github.event_name == 'merge_group'
@@ -95,7 +96,6 @@ jobs:
         echo "run_id=${run_id}" >> $GITHUB_OUTPUT
         echo "Test Run ID: ${run_id}"
         poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_e2e.html --self-contained-html tests/e2e
-        exit 1
     - name: Cleanup indexes
       if: (cancelled() || failure()) && github.event_name == 'merge_group'
       env:

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -79,7 +79,6 @@ jobs:
         echo "run_id=${run_id}" >> $GITHUB_OUTPUT
         echo "Test Run ID: ${run_id}"
         poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_system.html --self-contained-html tests/system
-        exit 1
     - name: Run e2e tests
       id: e2e_tests
       if: github.event_name == 'merge_group'

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -66,6 +66,7 @@ jobs:
         echo "${SUFFIX}"
         echo "INDEX_NAME_SUFFIX=${SUFFIX}" >> $GITHUB_OUTPUT
     - name: Run system tests
+      id: system_tests
       if: github.event_name == 'merge_group'
       env:
         INDEX_NAME: system-${{ steps.gen_suffix.outputs.INDEX_NAME_SUFFIX }}
@@ -74,8 +75,13 @@ jobs:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         ANYSCALE_API_KEY: ${{ secrets.ANYSCALE_API_KEY }}
         CO_API_KEY: ${{ secrets.CO_API_KEY }}
-      run: poetry run pytest -n 3 --dist loadscope --html=report_system.html --self-contained-html tests/system
+      run: |
+        run_id=$(uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]')
+        poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_system.html --self-contained-html tests/system
+        echo "Test Run ID: ${run_id}"
+        echo "run_id=${run_id}" >> $GITHUB_OUTPUT
     - name: Run e2e tests
+      id: e2e_tests
       if: github.event_name == 'merge_group'
       env:
         INDEX_NAME: e2e-${{ steps.gen_suffix.outputs.INDEX_NAME_SUFFIX }}
@@ -84,7 +90,26 @@ jobs:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         CO_API_KEY: ${{ secrets.CO_API_KEY }}
         CE_LOG_FILENAME: e2e.log
-      run: poetry run pytest -n 3 --dist loadscope --html=report_e2e.html --self-contained-html tests/e2e
+      run: |
+        run_id=$(uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]')
+        poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_e2e.html --self-contained-html tests/e2e
+        echo "Test Run ID: ${run_id}"
+        echo "run_id=${run_id}" >> $GITHUB_OUTPUT
+    - name: Cleanup indexes
+      if: failure() && github.event_name == 'merge_group'
+      env:
+        PINECONE_ENVIRONMENT: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_ENVIRONMENT_3 || secrets.PINECONE_ENVIRONMENT_4 }}
+        PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        ANYSCALE_API_KEY: ${{ secrets.ANYSCALE_API_KEY }}
+        CO_API_KEY: ${{ secrets.CO_API_KEY }}
+      run: |
+        python - <<EOF
+        from tests.util import cleanup_indexes
+        cleanup_indexes("${{ steps.e2e_tests.outputs.run_id }}")
+        cleanup_indexes("${{ steps.system_tests.outputs.run_id }}")
+        EOF
+      shell: bash
     - name: upload pytest report.html
       uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -102,8 +102,8 @@ jobs:
         PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}
       run: |
         export PYTHONPATH=.
-        python scripts/cleanup_indexes.py ${{ steps.e2e_tests.outputs.run_id }}
-        python scripts/cleanup_indexes.py ${{ steps.system_tests.outputs.run_id }}
+        poetry run python scripts/cleanup_indexes.py ${{ steps.e2e_tests.outputs.run_id }}
+        poetry run python scripts/cleanup_indexes.py ${{ steps.system_tests.outputs.run_id }}
     - name: upload pytest report.html
       uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -75,10 +75,10 @@ jobs:
         ANYSCALE_API_KEY: ${{ secrets.ANYSCALE_API_KEY }}
         CO_API_KEY: ${{ secrets.CO_API_KEY }}
       run: |
-        run_id=$(uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]')
-        poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_system.html --self-contained-html tests/system
-        echo "Test Run ID: ${run_id}"
+        run_id=$(uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]')     
         echo "run_id=${run_id}" >> $GITHUB_OUTPUT
+        echo "Test Run ID: ${run_id}"
+        poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_system.html --self-contained-html tests/system
     - name: Run e2e tests
       id: e2e_tests
 #      if: github.event_name == 'merge_group'
@@ -92,9 +92,9 @@ jobs:
         CE_LOG_FILENAME: e2e.log
       run: |
         run_id=$(uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]')
-        poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_e2e.html --self-contained-html tests/e2e
-        echo "Test Run ID: ${run_id}"
         echo "run_id=${run_id}" >> $GITHUB_OUTPUT
+        echo "Test Run ID: ${run_id}"
+        poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_e2e.html --self-contained-html tests/e2e
     - name: Cleanup indexes
       if: cancelled() || failure() #&& github.event_name == 'merge_group'
       env:

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -39,11 +39,14 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     needs: run-linters
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANYSCALE_API_KEY: ${{ secrets.ANYSCALE_API_KEY }}
+      CO_API_KEY: ${{ secrets.CO_API_KEY }}
     strategy:
       matrix:
         python-version: [3.9, '3.10', 3.11]
         pinecone-plan: ["paid", "starter"]
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -67,14 +70,11 @@ jobs:
         echo "INDEX_NAME_SUFFIX=${SUFFIX}" >> $GITHUB_OUTPUT
     - name: Run system tests
       id: system_tests
-      if: github.event_name == 'merge_group'
+#      if: github.event_name == 'merge_group'
       env:
         INDEX_NAME: system-${{ steps.gen_suffix.outputs.INDEX_NAME_SUFFIX }}
         PINECONE_ENVIRONMENT: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_ENVIRONMENT_3 || secrets.PINECONE_ENVIRONMENT_4 }}
         PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        ANYSCALE_API_KEY: ${{ secrets.ANYSCALE_API_KEY }}
-        CO_API_KEY: ${{ secrets.CO_API_KEY }}
       run: |
         run_id=$(uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]')
         poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_system.html --self-contained-html tests/system
@@ -82,13 +82,11 @@ jobs:
         echo "run_id=${run_id}" >> $GITHUB_OUTPUT
     - name: Run e2e tests
       id: e2e_tests
-      if: github.event_name == 'merge_group'
+#      if: github.event_name == 'merge_group'
       env:
         INDEX_NAME: e2e-${{ steps.gen_suffix.outputs.INDEX_NAME_SUFFIX }}
         PINECONE_ENVIRONMENT: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_ENVIRONMENT_3 || secrets.PINECONE_ENVIRONMENT_4 }}
         PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        CO_API_KEY: ${{ secrets.CO_API_KEY }}
         CE_LOG_FILENAME: e2e.log
       run: |
         run_id=$(uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]')
@@ -96,19 +94,14 @@ jobs:
         echo "Test Run ID: ${run_id}"
         echo "run_id=${run_id}" >> $GITHUB_OUTPUT
     - name: Cleanup indexes
-      if: failure() && github.event_name == 'merge_group'
+      if: failure() #&& github.event_name == 'merge_group'
       env:
         PINECONE_ENVIRONMENT: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_ENVIRONMENT_3 || secrets.PINECONE_ENVIRONMENT_4 }}
         PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        ANYSCALE_API_KEY: ${{ secrets.ANYSCALE_API_KEY }}
-        CO_API_KEY: ${{ secrets.CO_API_KEY }}
       run: |
-        python - <<EOF
-        from tests.util import cleanup_indexes
-        cleanup_indexes("${{ steps.e2e_tests.outputs.run_id }}")
-        cleanup_indexes("${{ steps.system_tests.outputs.run_id }}")
-        EOF
+        export PYTHONPATH=.
+        python scripts/cleanup_indexes.py ${{ steps.e2e_tests.outputs.run_id }}
+        python scripts/cleanup_indexes.py ${{ steps.system_tests.outputs.run_id }}
     - name: upload pytest report.html
       uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -109,7 +109,6 @@ jobs:
         cleanup_indexes("${{ steps.e2e_tests.outputs.run_id }}")
         cleanup_indexes("${{ steps.system_tests.outputs.run_id }}")
         EOF
-      shell: bash
     - name: upload pytest report.html
       uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -66,7 +66,7 @@ jobs:
         echo "INDEX_NAME_SUFFIX=${SUFFIX}" >> $GITHUB_OUTPUT
     - name: Run system tests
       id: system_tests
-#      if: github.event_name == 'merge_group'
+      if: github.event_name == 'merge_group'
       env:
         INDEX_NAME: system-${{ steps.gen_suffix.outputs.INDEX_NAME_SUFFIX }}
         PINECONE_ENVIRONMENT: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_ENVIRONMENT_3 || secrets.PINECONE_ENVIRONMENT_4 }}
@@ -81,7 +81,7 @@ jobs:
         poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_system.html --self-contained-html tests/system
     - name: Run e2e tests
       id: e2e_tests
-#      if: github.event_name == 'merge_group'
+      if: github.event_name == 'merge_group'
       env:
         INDEX_NAME: e2e-${{ steps.gen_suffix.outputs.INDEX_NAME_SUFFIX }}
         PINECONE_ENVIRONMENT: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_ENVIRONMENT_3 || secrets.PINECONE_ENVIRONMENT_4 }}
@@ -95,15 +95,16 @@ jobs:
         echo "run_id=${run_id}" >> $GITHUB_OUTPUT
         echo "Test Run ID: ${run_id}"
         poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_e2e.html --self-contained-html tests/e2e
+        exit 1
     - name: Cleanup indexes
-      if: cancelled() || failure() #&& github.event_name == 'merge_group'
+      if: (cancelled() || failure()) && github.event_name == 'merge_group'
       env:
         PINECONE_ENVIRONMENT: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_ENVIRONMENT_3 || secrets.PINECONE_ENVIRONMENT_4 }}
         PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}
       run: |
         export PYTHONPATH=.
-        echo ${{ steps.e2e_tests.outputs.run_id }}
-        echo ${{ steps.system_tests.outputs.run_id }}
+        poetry run python scripts/cleanup_indexes.py "${{ steps.e2e_tests.outputs.run_id }}"
+        poetry run python scripts/cleanup_indexes.py "${{ steps.system_tests.outputs.run_id }}"
     - name: upload pytest report.html
       uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -39,10 +39,6 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     needs: run-linters
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANYSCALE_API_KEY: ${{ secrets.ANYSCALE_API_KEY }}
-      CO_API_KEY: ${{ secrets.CO_API_KEY }}
     strategy:
       matrix:
         python-version: [3.9, '3.10', 3.11]
@@ -75,6 +71,9 @@ jobs:
         INDEX_NAME: system-${{ steps.gen_suffix.outputs.INDEX_NAME_SUFFIX }}
         PINECONE_ENVIRONMENT: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_ENVIRONMENT_3 || secrets.PINECONE_ENVIRONMENT_4 }}
         PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        ANYSCALE_API_KEY: ${{ secrets.ANYSCALE_API_KEY }}
+        CO_API_KEY: ${{ secrets.CO_API_KEY }}
       run: |
         run_id=$(uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]')
         poetry run pytest -n 3 --dist loadscope --testrunuid $run_id --html=report_system.html --self-contained-html tests/system
@@ -87,6 +86,9 @@ jobs:
         INDEX_NAME: e2e-${{ steps.gen_suffix.outputs.INDEX_NAME_SUFFIX }}
         PINECONE_ENVIRONMENT: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_ENVIRONMENT_3 || secrets.PINECONE_ENVIRONMENT_4 }}
         PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        ANYSCALE_API_KEY: ${{ secrets.ANYSCALE_API_KEY }}
+        CO_API_KEY: ${{ secrets.CO_API_KEY }}
         CE_LOG_FILENAME: e2e.log
       run: |
         run_id=$(uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -94,7 +94,7 @@ jobs:
         echo "Test Run ID: ${run_id}"
         echo "run_id=${run_id}" >> $GITHUB_OUTPUT
     - name: Cleanup indexes
-      if: failure() #&& github.event_name == 'merge_group'
+      if: cancelled() || failure() #&& github.event_name == 'merge_group'
       env:
         PINECONE_ENVIRONMENT: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_ENVIRONMENT_3 || secrets.PINECONE_ENVIRONMENT_4 }}
         PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -102,8 +102,6 @@ jobs:
         PINECONE_API_KEY: ${{ matrix.pinecone-plan == 'paid' && secrets.PINECONE_API_KEY_3 || secrets.PINECONE_API_KEY_4 }}
       run: |
         export PYTHONPATH=.
-#        poetry run python scripts/cleanup_indexes.py ${{ steps.e2e_tests.outputs.run_id }}
-#        poetry run python scripts/cleanup_indexes.py ${{ steps.system_tests.outputs.run_id }}
         poetry run python scripts/cleanup_indexes.py "aaaaaa"
         poetry run python scripts/cleanup_indexes.py "bbbbbb"
     - name: upload pytest report.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,5 @@ skip-checking-raises = true
 [tool.poetry.scripts]
 canopy = "canopy_cli.cli:cli"
 
+[tool.pytest.ini_options]
+log_cli = true

--- a/scripts/cleanup_indexes.py
+++ b/scripts/cleanup_indexes.py
@@ -3,11 +3,8 @@ import sys
 from tests.util import cleanup_indexes
 
 
-
 def main():
-    # Set the logging level to INFO
     logging.basicConfig(level=logging.INFO)
-
     logger = logging.getLogger(__name__)
 
     if len(sys.argv) != 2:

--- a/scripts/cleanup_indexes.py
+++ b/scripts/cleanup_indexes.py
@@ -1,0 +1,15 @@
+import sys
+from tests.util import cleanup_indexes
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python scripts/cleanup_indexes.py <testrun_uid>")
+        sys.exit(1)
+
+    testrun_uid = sys.argv[1]
+    cleanup_indexes(testrun_uid)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/cleanup_indexes.py
+++ b/scripts/cleanup_indexes.py
@@ -16,7 +16,7 @@ def main():
         logger.info(f"Cleaning up indexes for testrun_uid '{testrun_uid}'")
         cleanup_indexes(testrun_uid)
     else:
-        logger.info("testrun_uid is not passed, index cleanup will not be run.")
+        logger.info("Passed testrun_uid is empty.")
 
 
 if __name__ == '__main__':

--- a/scripts/cleanup_indexes.py
+++ b/scripts/cleanup_indexes.py
@@ -8,7 +8,11 @@ def main():
         sys.exit(1)
 
     testrun_uid = sys.argv[1]
-    cleanup_indexes(testrun_uid)
+    if testrun_uid:
+        print(f"Cleaning up indexes for testrun_uid: {testrun_uid}")
+        cleanup_indexes(testrun_uid)
+    else:
+        print("testrun_uid is not passed, index cleanup will not be run.")
 
 
 if __name__ == '__main__':

--- a/scripts/cleanup_indexes.py
+++ b/scripts/cleanup_indexes.py
@@ -1,18 +1,25 @@
+import logging
 import sys
 from tests.util import cleanup_indexes
 
 
+
 def main():
+    # Set the logging level to INFO
+    logging.basicConfig(level=logging.INFO)
+
+    logger = logging.getLogger(__name__)
+
     if len(sys.argv) != 2:
-        print("Usage: python scripts/cleanup_indexes.py <testrun_uid>")
+        logger.info("Usage: python scripts/cleanup_indexes.py <testrun_uid>")
         sys.exit(1)
 
     testrun_uid = sys.argv[1]
     if testrun_uid:
-        print(f"Cleaning up indexes for testrun_uid: {testrun_uid}")
+        logger.info(f"Cleaning up indexes for testrun_uid '{testrun_uid}'")
         cleanup_indexes(testrun_uid)
     else:
-        print("testrun_uid is not passed, index cleanup will not be run.")
+        logger.info("testrun_uid is not passed, index cleanup will not be run.")
 
 
 if __name__ == '__main__':

--- a/tests/system/knowledge_base/test_knowledge_base.py
+++ b/tests/system/knowledge_base/test_knowledge_base.py
@@ -71,6 +71,7 @@ def knowledge_base(index_full_name, index_name, chunker, encoder):
                        record_encoder=encoder,
                        chunker=chunker)
     kb.create_canopy_index(indexed_fields=["my-key"])
+
     return kb
 
 

--- a/tests/system/knowledge_base/test_knowledge_base.py
+++ b/tests/system/knowledge_base/test_knowledge_base.py
@@ -1,17 +1,17 @@
 import os
 import random
 
-import pytest
-import pinecone
 import numpy as np
+import pinecone
+import pytest
+from dotenv import load_dotenv
 from tenacity import (
     retry,
     stop_after_delay,
     wait_fixed,
     wait_chain,
 )
-from dotenv import load_dotenv
-from datetime import datetime
+
 from canopy.knowledge_base import KnowledgeBase, list_canopy_indexes
 from canopy.knowledge_base.chunker import Chunker
 from canopy.knowledge_base.knowledge_base import INDEX_NAME_PREFIX
@@ -19,11 +19,11 @@ from canopy.knowledge_base.models import DocumentWithScore
 from canopy.knowledge_base.record_encoder import RecordEncoder
 from canopy.knowledge_base.reranker import Reranker
 from canopy.models.data_models import Document, Query
-from tests.unit.stubs.stub_record_encoder import StubRecordEncoder
-from tests.unit.stubs.stub_dense_encoder import StubDenseEncoder
-from tests.unit.stubs.stub_chunker import StubChunker
 from tests.unit import random_words
-
+from tests.unit.stubs.stub_chunker import StubChunker
+from tests.unit.stubs.stub_dense_encoder import StubDenseEncoder
+from tests.unit.stubs.stub_record_encoder import StubRecordEncoder
+from tests.util import create_system_tests_index_name
 
 load_dotenv()
 
@@ -42,8 +42,7 @@ def retry_decorator():
 
 @pytest.fixture(scope="module")
 def index_name(testrun_uid):
-    today = datetime.today().strftime("%Y-%m-%d")
-    return f"test-kb-{testrun_uid[-6:]}-{today}"
+    return create_system_tests_index_name(testrun_uid)
 
 
 @pytest.fixture(scope="module")
@@ -72,7 +71,6 @@ def knowledge_base(index_full_name, index_name, chunker, encoder):
                        record_encoder=encoder,
                        chunker=chunker)
     kb.create_canopy_index(indexed_fields=["my-key"])
-
     return kb
 
 
@@ -299,7 +297,6 @@ def test_update_documents(encoder,
                           documents,
                           encoded_chunks,
                           knowledge_base):
-
     index_name = knowledge_base._index_name
 
     # chunker/kb that produces fewer chunks per doc

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,34 @@
+import logging
+from datetime import datetime
+
+import pinecone
+
+logger = logging.getLogger(__name__)
+
+
+def create_index_name(testrun_uid: str, prefix: str) -> str:
+    today = datetime.today().strftime("%Y-%m-%d")
+    return f"{prefix}-{testrun_uid[-6:]}-{today}"
+
+
+def create_system_tests_index_name(testrun_uid: str) -> str:
+    return create_index_name(testrun_uid, "test-kb")
+
+
+def create_e2e_tests_index_name(testrun_uid: str) -> str:
+    return create_index_name(testrun_uid, "test-app")
+
+
+def cleanup_indexes(testrun_uid: str):
+    pinecone.init()
+    e2e_index_name = create_e2e_tests_index_name(testrun_uid)
+    system_index_name = create_system_tests_index_name(testrun_uid)
+    index_names = (system_index_name, e2e_index_name)
+    logger.info(f"Preparing to cleanup indexes: {index_names}")
+    current_indexes = pinecone.list_indexes()
+    for index_name in index_names:
+        if index_name in current_indexes:
+            logger.info(f"Deleting index: {index_name}")
+            pinecone.delete_index(index_name)
+        else:
+            logger.info(f"Index: {index_name} already deleted.")

--- a/tests/util.py
+++ b/tests/util.py
@@ -28,7 +28,8 @@ def cleanup_indexes(testrun_uid: str):
     current_indexes = pinecone.list_indexes()
     for index_name in index_names:
         if index_name in current_indexes:
-            logger.info(f"Deleting index: {index_name}")
+            logger.info(f"Deleting index '{index_name}'...")
             pinecone.delete_index(index_name)
+            logger.info(f"Index '{index_name}' deleted.")
         else:
-            logger.info(f"Index: {index_name} already deleted.")
+            logger.info(f"Index '{index_name}' does not exist.")


### PR DESCRIPTION
## Problem

When an action get cancelled pytest is stopped using SIGKILL (by Github CI) which causes unused indexes to remain after the test.

## Solution

Add a new step to clean up the indexes in case the run is interrupted in the middle.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
