### PR TITLE
Parameterize [server, pod] and [namespace] across all tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canopy-sdk"
-version = "0.5.0"
+version = "0.6.0"
 description = "Retrieval Augmented Generation (RAG) framework and context engine powered by Pinecone"
 authors = ["Relevance Team <relevance@pinecone.io>"]
 readme = "README.md"

--- a/src/canopy/knowledge_base/knowledge_base.py
+++ b/src/canopy/knowledge_base/knowledge_base.py
@@ -22,8 +22,8 @@ from canopy.knowledge_base.reranker import Reranker, TransparentReranker
 from canopy.models.data_models import Query, Document
 
 INDEX_NAME_PREFIX = "canopy--"
-TIMEOUT_INDEX_CREATE = 30
-TIMEOUT_INDEX_PROVISION = 300
+TIMEOUT_INDEX_CREATE = 90
+TIMEOUT_INDEX_PROVISION = 120
 INDEX_PROVISION_TIME_INTERVAL = 3
 RESERVED_METADATA_KEYS = {"document_id", "text", "source"}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+TEST_NAMESPACE = "ns"
+TEST_CREATE_INDEX_PARAMS = [
+    {"spec": {"serverless": {"cloud": "aws", "region": "us-west-2"}}},
+    {"spec": {"pod": {"environment": "eu-west1-gcp", "pod_type": "p1.x1"}}},
+]
+
+
+@pytest.fixture(scope="module", params=[None, TEST_NAMESPACE])
+def namespace(request):
+    return request.param
+
+
+@pytest.fixture(scope="module",
+                params=TEST_CREATE_INDEX_PARAMS,
+                # The first key in the spec is the index type ("serverless" \ "pod")
+                ids=[next(iter(_["spec"])) for _ in TEST_CREATE_INDEX_PARAMS])
+def create_index_params(request):
+    return request.param

--- a/tests/e2e/test_app.py
+++ b/tests/e2e/test_app.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 import pytest
 from fastapi.testclient import TestClient
-from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 from canopy.knowledge_base import KnowledgeBase
 from canopy.knowledge_base.knowledge_base import list_canopy_indexes
@@ -16,7 +16,7 @@ from canopy_server.models.v1.api_models import (
     ContextUpsertRequest,
     ContextQueryRequest)
 from .. import Tokenizer
-from ..util import create_e2e_tests_index_name, TEST_NAMESPACE, TEST_CREATE_INDEX_PARAMS
+from ..util import create_e2e_tests_index_name
 
 upsert_payload = ContextUpsertRequest(
     documents=[
@@ -28,19 +28,6 @@ upsert_payload = ContextUpsertRequest(
         }
     ],
 )
-
-
-@pytest.fixture(scope="module", params=[None, TEST_NAMESPACE])
-def namespace(request):
-    return request.param
-
-
-@pytest.fixture(scope="module",
-                params=TEST_CREATE_INDEX_PARAMS,
-                # The first key in the spec is the index type ("serverless" \ "pod")
-                ids=[next(iter(_["spec"])) for _ in TEST_CREATE_INDEX_PARAMS])
-def create_index_params(request):
-    return request.param
 
 
 @pytest.fixture(scope="module")

--- a/tests/system/knowledge_base/test_knowledge_base.py
+++ b/tests/system/knowledge_base/test_knowledge_base.py
@@ -1,4 +1,5 @@
 import random
+from typing import Dict, Any, Optional
 
 import pytest
 import numpy as np
@@ -59,12 +60,12 @@ def encoder():
         StubDenseEncoder())
 
 
-def try_create_canopy_index(kb: KnowledgeBase):
-    kb.create_canopy_index()
+def try_create_canopy_index(kb: KnowledgeBase, init_params: Dict[str, Any]):
+    kb.create_canopy_index(**init_params)
 
 
 @pytest.fixture(scope="module", autouse=True)
-def knowledge_base(index_full_name, index_name, chunker, encoder):
+def knowledge_base(index_full_name, index_name, chunker, encoder, create_index_params):
     kb = KnowledgeBase(index_name=index_name,
                        record_encoder=encoder,
                        chunker=chunker)
@@ -72,7 +73,7 @@ def knowledge_base(index_full_name, index_name, chunker, encoder):
     if index_full_name in list_canopy_indexes():
         _get_global_client().delete_index(index_full_name)
 
-    try_create_canopy_index(kb)
+    try_create_canopy_index(kb, create_index_params)
 
     return kb
 

--- a/tests/system/knowledge_base/test_knowledge_base.py
+++ b/tests/system/knowledge_base/test_knowledge_base.py
@@ -59,7 +59,6 @@ def encoder():
         StubDenseEncoder())
 
 
-@retry(reraise=True, stop=stop_after_attempt(5), wait=wait_random(min=10, max=20))
 def try_create_canopy_index(kb: KnowledgeBase):
     kb.create_canopy_index()
 

--- a/tests/system/knowledge_base/test_knowledge_base.py
+++ b/tests/system/knowledge_base/test_knowledge_base.py
@@ -1,5 +1,5 @@
 import random
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 import pytest
 import numpy as np
@@ -8,7 +8,7 @@ from tenacity import (
     retry,
     stop_after_delay,
     wait_fixed,
-    wait_chain, stop_after_attempt, wait_random,
+    wait_chain,
 )
 
 from canopy.knowledge_base import KnowledgeBase

--- a/tests/unit/chat_engine/test_chat_engine.py
+++ b/tests/unit/chat_engine/test_chat_engine.py
@@ -13,7 +13,6 @@ from canopy.llm import BaseLLM
 from canopy.models.api_models import ChatResponse, _Choice, TokenCounts
 from canopy.models.data_models import MessageBase, Query, Context, Role
 from .. import random_words
-from ...util import TEST_NAMESPACE
 
 MOCK_SYSTEM_PROMPT = "This is my mock prompt"
 MAX_PROMPT_TOKENS = 100
@@ -101,9 +100,6 @@ class TestChatEngine:
         }
         return messages, expected
 
-    @pytest.mark.parametrize("namespace", [
-        None, TEST_NAMESPACE
-    ])
     def test_chat(self, namespace, history_length=5, snippet_length=10):
 
         chat_engine = self._init_chat_engine()
@@ -137,9 +133,6 @@ class TestChatEngine:
 
         assert response == expected['response']
 
-    @pytest.mark.parametrize("namespace", [
-        None, TEST_NAMESPACE
-    ])
     def test_chat_engine_params(self,
                                 namespace,
                                 system_prompt_length=10,

--- a/tests/unit/context_engine/test_context_engine.py
+++ b/tests/unit/context_engine/test_context_engine.py
@@ -11,7 +11,6 @@ from canopy.context_engine.context_builder.stuffing import (ContextSnippet,
 from canopy.knowledge_base.base import BaseKnowledgeBase
 from canopy.knowledge_base.models import QueryResult, DocumentWithScore
 from canopy.models.data_models import Query, Context, ContextContent
-from tests.util import TEST_NAMESPACE
 
 
 @pytest.fixture
@@ -58,11 +57,6 @@ def mock_query_result(sample_context_text):
             ]
         )
     ]
-
-
-@pytest.fixture(scope="module", params=[None, TEST_NAMESPACE])
-def namespace(request):
-    return request.param
 
 
 def test_query(context_engine,

--- a/tests/util.py
+++ b/tests/util.py
@@ -8,8 +8,7 @@ logger = logging.getLogger(__name__)
 TEST_NAMESPACE = "ns"
 TEST_CREATE_INDEX_PARAMS = [
     {"spec": {"serverless": {"cloud": "aws", "region": "us-west-2"}}},
-    # TODO: Enable this
-    # {"spec": {"pod": {"environment": "eu-west1-gcp", "pod_type": "p1.x1"}}},
+    {"spec": {"pod": {"environment": "eu-west1-gcp", "pod_type": "p1.x1"}}},
 ]
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -5,12 +5,6 @@ from canopy.knowledge_base.knowledge_base import _get_global_client
 
 logger = logging.getLogger(__name__)
 
-TEST_NAMESPACE = "ns"
-TEST_CREATE_INDEX_PARAMS = [
-    {"spec": {"serverless": {"cloud": "aws", "region": "us-west-2"}}},
-    {"spec": {"pod": {"environment": "eu-west1-gcp", "pod_type": "p1.x1"}}},
-]
-
 
 def create_index_name(testrun_uid: str, prefix: str) -> str:
     today = datetime.today().strftime("%Y-%m-%d")


### PR DESCRIPTION
## Problem

- System and e2e tests were only running for `serverless` indexes
- Some tests didn't parameterize with\without namespace
- A lot of duplication around parameterization

## Solution

- Removed the redundant `retry` on `create_index`. Instead - increased TIMEOUT in the KB itself
- Created a centralized `conftests.py` with fixtures that can be used in any tests (unit, system and e2e)
- Parameterized most tests over both [serverless, pod] and [namespace, None]

Not included:
- Parameterizing `kb` system test to use `namespace`
- More efficient parallelization (namely, define test dependencies so we can remove `--dist loadspec`)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)