### PR TITLE
Fix docker autorelease

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -2,6 +2,17 @@ name: Create and publish a Docker image
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag the image with'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to tag the image with'
+        required: true
+        type: string
   push:
     branches:
       - 'main'
@@ -31,10 +42,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-              ghcr.io/pinecone-io/canopy
+              ghcr.io/${{ github.repository }}
           tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
+            type=ref,event=branch,enable=${{ github.event_name == 'push' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'push' }}
+            type=raw,value=latest,enable=${{ github.event_name != 'push' }}
+            type=raw,value=${{inputs.version}},enable=${{ github.event_name != 'push' }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,3 +155,8 @@ jobs:
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
           poetry publish
+  publish-image:
+    needs: [build, publish]
+    uses: ./.github/workflows/build-push-image.yml
+    with:
+      version: ${{ needs.build.outputs.new_version }}


### PR DESCRIPTION
## Problem

Autorelease for images do not work on releases.

## Solution

Changed the CI to call another workflow instead of relying the tag pushes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Tested using a demo repository.