### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Canopy is using FastAPI as the web framework and Uvicorn as the ASGI server. It 
 To run the canopy server for production, please run:
 
 ```bash
-gunicorn canopy_cli.app:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --workers <number of desired worker processes>
+gunicorn canopy_server.app:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --workers <number of desired worker processes>
 ```
 
 Alternatively, consider utilizing the Canopy Docker image available on [GitHub Packages](https://github.com/pinecone-io/canopy/pkgs/container/canopy) 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Canopy is using FastAPI as the web framework and Uvicorn as the ASGI server. It 
 To run the canopy server for production, please run:
 
 ```bash
-gunicorn canopy_server.app:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --workers <number of desired worker processes>
+gunicorn canopy_server.app:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:PORT --workers WORKER_COUNT
 ```
 
 Alternatively, consider utilizing the Canopy Docker image available on [GitHub Packages](https://github.com/pinecone-io/canopy/pkgs/container/canopy) 


### PR DESCRIPTION
Update the gunicorn command to: gunicorn canopy_server.app:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --workers <number of desired worker processes>

## Problem
The gunicorn command is not correct:
gunicorn canopy_cli.app:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --workers <number of desired worker processes>

## Solution
I have updated the command to:
gunicorn canopy_server.app:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --workers <number of desired worker processes>

## Type of Change

- updated the gunicron command on README.md

## Test Plan

Now run:
gunicorn canopy_server.app:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --workers <number of desired worker processes>
And good to go