### PR TITLE
Move chunk id generation to base

### DIFF
--- a/examples/canopy-lib-quickstart.ipynb
+++ b/examples/canopy-lib-quickstart.ipynb
@@ -753,7 +753,7 @@
     "     def chunk_single_document(self, document: Document) -> List[KBDocChunk]:\n",
     "        line_chunks = [chunk\n",
     "                       for chunk in document.text.split(\"\\n\")]\n",
-    "        return [KBDocChunk(id=f\"{document.id}_{i}\",\n",
+    "        return [KBDocChunk(id=self.generate_chunk_id(document.id, i),\n",
     "                           document_id=document.id,\n",
     "                           text=text_chunk,\n",
     "                           source=document.source,\n",

--- a/src/canopy/knowledge_base/chunker/base.py
+++ b/src/canopy/knowledge_base/chunker/base.py
@@ -7,7 +7,6 @@ from canopy.utils.config import ConfigurableMixin
 
 
 class Chunker(ABC, ConfigurableMixin):
-
     """
     Base class for chunkers. Chunkers take a document (id, text, ...)
     and return a list of KBDocChunks  (id, text, document_id, ...)
@@ -57,3 +56,6 @@ class Chunker(ABC, ConfigurableMixin):
     @abstractmethod
     async def achunk_single_document(self, document: Document) -> List[KBDocChunk]:
         raise NotImplementedError()
+
+    def generate_chunk_id(self, document_id: str, chunk_index: int) -> str:
+        return f"{document_id}_{chunk_index}"

--- a/src/canopy/knowledge_base/chunker/recursive_character.py
+++ b/src/canopy/knowledge_base/chunker/recursive_character.py
@@ -52,7 +52,7 @@ class RecursiveCharacterChunker(Chunker):
         """  # noqa: E501
         # TODO: check overlap not bigger than max_chunk_size
         text_chunks = self._chunker.split_text(document.text)
-        return [KBDocChunk(id=f"{document.id}_{i}",
+        return [KBDocChunk(id=self.generate_chunk_id(document.id, i),
                            document_id=document.id,
                            text=text_chunk,
                            source=document.source,

--- a/src/canopy/knowledge_base/chunker/token_chunker.py
+++ b/src/canopy/knowledge_base/chunker/token_chunker.py
@@ -69,7 +69,7 @@ class TokenChunker(Chunker):
 
         text_chunks = [self._tokenizer.detokenize(chunk)
                        for chunk in token_chunks]
-        return [KBDocChunk(id=f"{document.id}_{i}",
+        return [KBDocChunk(id=self.generate_chunk_id(document.id, i),
                            document_id=document.id,
                            text=text_chunk,
                            source=document.source,

--- a/tests/unit/stubs/stub_chunker.py
+++ b/tests/unit/stubs/stub_chunker.py
@@ -15,7 +15,7 @@ class StubChunker(Chunker):
             return []
 
         # simply duplicate docs as chunks
-        return [KBDocChunk(id=f"{document.id}_{i}",
+        return [KBDocChunk(id=self.generate_chunk_id(document.id, i),
                            document_id=document.id,
                            text=document.text + (f" dup_{i}" if i > 0 else ""),
                            source=document.source,


### PR DESCRIPTION
## Problem

Every chunker has its own way of creating chunk ids. We should generalise that to prevent discrepancies.

## Solution

Created a function in the base and changed all child classes to call that function instead.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
