### PR TITLE
__init__ fix: CohereEncoder -> CohereRecordEncoder

### DIFF
--- a/src/canopy/knowledge_base/record_encoder/__init__.py
+++ b/src/canopy/knowledge_base/record_encoder/__init__.py
@@ -1,5 +1,5 @@
 from .base import RecordEncoder
-from .cohere import CohereEncoder
+from .cohere import CohereRecordEncoder
 from .dense import DenseRecordEncoder
 from .openai import OpenAIRecordEncoder
 from .anyscale import AnyscaleRecordEncoder


### PR DESCRIPTION
## Problem

`CohereEncoder` (i.e. the class from `pinecone_text`) was being exported via `__init__.py` rather than `CohereRecordEncoder`.

## Solution

I replaced `CohereEncoder` with `CohereRecordEncoder`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

You can try to import `CohereRecordEncoder` via `canopy.knowledge_base.record_encoder` - this was not possible before.

- Tom Aarsen