### PR TITLE
Make transformers optional + allow pinecone-text[dense]

### DIFF
--- a/.github/actions/install-deps-and-canopy/action.yml
+++ b/.github/actions/install-deps-and-canopy/action.yml
@@ -43,7 +43,7 @@ runs:
     if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
     env:
       CANOPY_EXTRAS: ${{ inputs.extras }}
-    run: poetry install --no-interaction --no-root --with dev --extras "{{ env.CANOPY_EXTRAS }}"
+    run: poetry install --no-interaction --no-root --with dev --extras "{$CANOPY_EXTRAS}"
   - name: Install project
     if: ${{ inputs.install-canopy == 'true' }}
     shell: bash

--- a/.github/actions/install-deps-and-canopy/action.yml
+++ b/.github/actions/install-deps-and-canopy/action.yml
@@ -43,7 +43,7 @@ runs:
     if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
     env:
       CANOPY_EXTRAS: ${{ inputs.extras }}
-    run: poetry install --no-interaction --no-root --with dev --extras "{$CANOPY_EXTRAS}"
+    run: poetry install --no-interaction --no-root --with dev --extras "${CANOPY_EXTRAS}"
   - name: Install project
     if: ${{ inputs.install-canopy == 'true' }}
     shell: bash

--- a/.github/actions/install-deps-and-canopy/action.yml
+++ b/.github/actions/install-deps-and-canopy/action.yml
@@ -9,9 +9,15 @@ inputs:
     description: "Whether to install canopy library, or dependencies only"
     required: true
     default: "true"
+  extras:
+    description: "Extra dependencies to install"
+    required: false
+    default: "cohere transformers"
 
 runs:
   using: "composite"
+  env:
+    CANOPY_EXTRAS: ${{ inputs.extras }}
   steps:
   - name: Install Poetry
     uses: snok/install-poetry@v1
@@ -37,8 +43,8 @@ runs:
   - name: Install dependencies
     shell: bash
     if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-    run: poetry install --no-interaction --no-root --all-extras --with dev
+    run: poetry install --no-interaction --no-root --with dev --extras "{{ env.CANOPY_EXTRAS }}"
   - name: Install project
     if: ${{ inputs.install-canopy == 'true' }}
     shell: bash
-    run: poetry install --no-interaction --all-extras --with dev
+    run: make install-extras

--- a/.github/actions/install-deps-and-canopy/action.yml
+++ b/.github/actions/install-deps-and-canopy/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
     default: "true"
   extras:
-    description: "Extra dependencies to install"
+    description: "Extra dependencies to install, space separated"
     required: false
     default: "cohere transformers"
 

--- a/.github/actions/install-deps-and-canopy/action.yml
+++ b/.github/actions/install-deps-and-canopy/action.yml
@@ -16,8 +16,6 @@ inputs:
 
 runs:
   using: "composite"
-  env:
-    CANOPY_EXTRAS: ${{ inputs.extras }}
   steps:
   - name: Install Poetry
     uses: snok/install-poetry@v1
@@ -43,8 +41,12 @@ runs:
   - name: Install dependencies
     shell: bash
     if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+    env:
+      CANOPY_EXTRAS: ${{ inputs.extras }}
     run: poetry install --no-interaction --no-root --with dev --extras "{{ env.CANOPY_EXTRAS }}"
   - name: Install project
     if: ${{ inputs.install-canopy == 'true' }}
     shell: bash
+    env:
+      CANOPY_EXTRAS: ${{ inputs.extras }}
     run: make install-extras

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ lint:
 static:
 	poetry run mypy src
 
+install-extras:
+	poetry install --with dev --extras "$(CANOPY_EXTRAS)"
+
 test:
 	poetry run pytest -n $(TEST_WORKER_COUNT) --dist loadscope
 

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,16 @@ CONTAINER_EXTRA_BUILD_ARGS =
 CONTAINER_COMMON_RUN_ARGS = --platform linux/amd64 -p $(CONTAINER_PORT):$(CONTAINER_PORT) $(shell [ -e "$(CONTAINER_ENV_FILE)" ] && echo "--env-file $(CONTAINER_ENV_FILE)")
 CONTAINER_EXTRA_RUN_ARGS =
 
-.PHONY: lint static test test-unit test-system test-e2e install docker-build docker-build-dev docker-run docker-run-dev help
+.PHONY: lint static install install-extras test test-unit test-system test-e2e install docker-build docker-build-dev docker-run docker-run-dev help
 
 lint:
 	poetry run flake8 .
 
 static:
 	poetry run mypy src
+
+install:
+	poetry install
 
 install-extras:
 	poetry install --with dev --extras "$(CANOPY_EXTRAS)"
@@ -37,8 +40,6 @@ test-system:
 test-e2e:
 	poetry run pytest -n $(TEST_WORKER_COUNT) --dist loadscope tests/e2e
 
-install:
-	poetry install
 docker-build:
 	@echo "Building Docker image..."
 	docker build $(CONTAINER_COMMON_BUILD_ARGS) $(CONTAINER_EXTRA_BUILD_ARGS) -t $(REPOSITORY):$(IMAGE_TAG) $(CONTAINER_BUILD_DIR)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ cohere = { version = ">=4.37", optional = true }
 [tool.poetry.extras]
 cohere = ["cohere"]
 torch = ["pinecone-text"]
-anyscale = ["transformers"]
+transformers = ["transformers"]
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,11 @@ types-pyyaml = "^6.0.12.12"
 jsonschema = "^4.2.0"
 types-jsonschema = "^4.2.0"
 prompt-toolkit = "^3.0.39"
-pinecone-text = "^0.7.2"
+pinecone-text = [{version = "^0.7.2"},
+                 {version = "^0.7.2", extras = ["dense"], optional = true}]
+
 tokenizers = "^0.15.0"
-transformers = "^4.35.2"
+transformers = {version = "^4.35.2", optional = true}
 sentencepiece = "^0.1.99"
 pandas = "2.0.0"
 pyarrow = "^14.0.1"
@@ -38,6 +40,8 @@ cohere = { version = ">=4.37", optional = true }
 
 [tool.poetry.extras]
 cohere = ["cohere"]
+torch = ["pinecone-text"]
+anyscale = ["transformers"]
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/canopy/tokenizer/llama.py
+++ b/src/canopy/tokenizer/llama.py
@@ -2,7 +2,13 @@ from typing import List
 from .base import BaseTokenizer
 from ..models.data_models import Messages
 import os
-from transformers import LlamaTokenizerFast as HfTokenizer
+
+try:
+    from transformers import LlamaTokenizerFast as HfTokenizer
+except (OSError, ImportError, ModuleNotFoundError) as e:
+    _tranformers_installed = False
+else:
+    _tranformers_installed = True
 
 
 class LlamaTokenizer(BaseTokenizer):
@@ -37,6 +43,13 @@ class LlamaTokenizer(BaseTokenizer):
             model_name: The name of the model to use. Defaults to "openlm-research/open_llama_7b_v2".
             hf_token: Huggingface token
         """  # noqa: E501
+        if not _tranformers_installed:
+            raise ImportError(
+                "The transformers library is required to use the LlamaTokenizer. "
+                "Please install canopy with the [transformers] extra: "
+                "pip install canopy-sdk[transformers]"
+            )
+
         hf_token = hf_token or os.environ.get("HUGGINGFACE_TOKEN", "")
         # Add legacy=True to avoid extra printings
         self._encoder = HfTokenizer.from_pretrained(

--- a/src/canopy/tokenizer/llama.py
+++ b/src/canopy/tokenizer/llama.py
@@ -5,7 +5,7 @@ import os
 
 try:
     from transformers import LlamaTokenizerFast as HfTokenizer
-except (OSError, ImportError, ModuleNotFoundError) as e:
+except (OSError, ImportError, ModuleNotFoundError):
     _tranformers_installed = False
 else:
     _tranformers_installed = True

--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -339,7 +339,7 @@ def upsert(index_name: str,
 
     try:
         kb.connect()
-    except (RuntimeError) as e:
+    except RuntimeError as e:
         # TODO: kb should throw a specific exception for each case
         msg = str(e)
         raise CLIError(msg)

--- a/src/canopy_cli/cli.py
+++ b/src/canopy_cli/cli.py
@@ -145,11 +145,12 @@ def _load_kb_config(config_file: Optional[str]) -> Dict[str, Any]:
 
 def _validate_chat_engine(config_file: Optional[str]):
     config = _read_config_file(config_file)
-    Tokenizer.initialize()
+    tokenizer_config = config.get("tokenizer", {})
     try:
         # If the server itself will fail, we can't except the error, since it's running
         # in a different process. Try to load and run the ChatEngine so we can catch
         # any errors and print a nice message.
+        Tokenizer.initialize_from_config(tokenizer_config)
         chat_engine = ChatEngine.from_config(config.get("chat_engine", {}))
         chat_engine.max_generated_tokens = 5
         chat_engine.context_engine.knowledge_base.connect()
@@ -338,7 +339,7 @@ def upsert(index_name: str,
 
     try:
         kb.connect()
-    except RuntimeError as e:
+    except (RuntimeError) as e:
         # TODO: kb should throw a specific exception for each case
         msg = str(e)
         raise CLIError(msg)


### PR DESCRIPTION
## Problem

1. `transformers` shouldn't be a required dependency. It was accidentally added as such.
2. No way to install `pinecone-text` with its `[dense]` extra dependency

## Solution

1. Made `transformers` optional, only installed with a new `anyscale` extra
2. Added a new `torch` extra (torch is the heaviest installation, so it made more sense as the extra's name than `transformers` or `sentence-transformers`, which might be ambiguous)

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Might be slightly breaking for users who currently use the Anyscale Tokenizer, and would need to re-install with the extra.

## Test Plan

No affect on current tests
