### PR TITLE
Add snippet ids to context builder debug info

### DIFF
--- a/src/canopy/context_engine/context_builder/stuffing.py
+++ b/src/canopy/context_engine/context_builder/stuffing.py
@@ -2,6 +2,7 @@ from itertools import zip_longest
 from typing import List, Tuple
 
 from pydantic import BaseModel
+from canopy.utils.debugging import CANOPY_DEBUG_INFO
 
 from canopy.context_engine.context_builder.base import ContextBuilder
 from canopy.knowledge_base.models import QueryResult, DocumentWithScore
@@ -50,7 +51,7 @@ class StuffingContextBuilder(ContextBuilder):
         context_query_results = [
             ContextQueryResult(query=qr.query, snippets=[])
             for qr in query_results]
-        debug_info = {"num_docs": len(sorted_docs_with_origin)}
+        debug_info = {"num_docs": len(sorted_docs_with_origin), "snippet_ids": []}
         content = StuffingContextContent(__root__=context_query_results)
 
         if self._tokenizer.token_count(content.to_text()) > max_context_tokens:
@@ -58,6 +59,7 @@ class StuffingContextBuilder(ContextBuilder):
                            num_tokens=1, debug_info=debug_info)
 
         seen_doc_ids = set()
+        snippet_ids = []
         for doc, origin_query_idx in sorted_docs_with_origin:
             if doc.id not in seen_doc_ids and doc.text.strip() != "":
                 snippet = ContextSnippet(text=doc.text, source=doc.source)
@@ -69,6 +71,10 @@ class StuffingContextBuilder(ContextBuilder):
                 # if the context is too long, remove the snippet
                 if self._tokenizer.token_count(content.to_text()) > max_context_tokens:
                     context_query_results[origin_query_idx].snippets.pop()
+                else:
+                    snippet_ids.append(doc.id)
+
+        debug_info["snippet_ids"] = snippet_ids
 
         # remove queries with no snippets
         content = StuffingContextContent(
@@ -77,7 +83,7 @@ class StuffingContextBuilder(ContextBuilder):
 
         return Context(content=content,
                        num_tokens=self._tokenizer.token_count(content.to_text()),
-                       debug_info=debug_info)
+                       debug_info=debug_info if CANOPY_DEBUG_INFO else {})
 
     @staticmethod
     def _round_robin_sort(


### PR DESCRIPTION
## Problem

Currently the debug info not includes the sorted list of snippet ids that actually included in the final context. This blocks the option to measure standard IR metrics like NDCG or MRR.

## Solution

Add snippet ids list to debug infro in the context builder.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Existing tests apply