### PR TITLE
Support optional imports in unit tests

### DIFF
--- a/tests/unit/tokenizer/test_cohere_hf_tokenizer.py
+++ b/tests/unit/tokenizer/test_cohere_hf_tokenizer.py
@@ -8,7 +8,14 @@ class TestCohereHFTokenizer(BaseTestTokenizer):
     @staticmethod
     @pytest.fixture(scope="class")
     def tokenizer():
-        return CohereHFTokenizer()
+        try:
+            tokenizer = CohereHFTokenizer()
+        except ImportError:
+            pytest.skip(
+                "`cohere` extra not installed. Skipping CohereHFTokenizer unit "
+                "tests"
+            )
+        return tokenizer
 
     @staticmethod
     @pytest.fixture

--- a/tests/unit/tokenizer/test_llama_tokenizer.py
+++ b/tests/unit/tokenizer/test_llama_tokenizer.py
@@ -8,7 +8,14 @@ class TestLlamaTokenizer(BaseTestTokenizer):
     @staticmethod
     @pytest.fixture(scope="class")
     def tokenizer():
-        return LlamaTokenizer(model_name="hf-internal-testing/llama-tokenizer")
+        try:
+            tokenizer = LlamaTokenizer(model_name="hf-internal-testing/llama-tokenizer")
+        except ImportError:
+            pytest.skip(
+                "`transformers` extra not installed. Skipping LLamaTokenizer unit "
+                "tests"
+            )
+        return tokenizer
 
     @staticmethod
     @pytest.fixture


### PR DESCRIPTION
## Problem

After setting up the environment without extras, some unit tests are failing that blocks the release.

## Solution

Make sure to optionally import dependencies in unit tests in case no extras is installed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
