### PR TITLE
Remove JINA API key from mandatory env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ pip install canopy-sdk
 ```bash
 export PINECONE_API_KEY="<PINECONE_API_KEY>"
 export OPENAI_API_KEY="<OPENAI_API_KEY>"
-export JINA_API_KEY="<JINA_API_KEY>"
 export INDEX_NAME="<INDEX_NAME>"
 ```
 


### PR DESCRIPTION
## Problem

JINA API key is not necessary to set up Canopy, so removed from README.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

