### PR TITLE
Treat gcp starter same as serverless for delete by metadata

### DIFF
--- a/tests/system/knowledge_base/test_knowledge_base.py
+++ b/tests/system/knowledge_base/test_knowledge_base.py
@@ -322,7 +322,7 @@ def test_update_documents(encoder,
     expected_chunks = [chunk.id for chunk in updated_chunks]
     assert_chunks_in_index(kb, updated_chunks)
 
-    if not knowledge_base._is_serverless_env():
+    if not knowledge_base._is_serverless_or_starter_env():
         unexpected_chunks = [c_id for c_id in chunk_ids
                              if c_id not in expected_chunks]
         assert len(unexpected_chunks) > 0, "bug in the test itself"


### PR DESCRIPTION
## Problem

Starter env don't support delete by metadata

## Solution

Treat starter env indexes same as serverless for vector deletion

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Manually tested gcp-starter