### PR TITLE
Remove unused field for Cohere chat calls

### DIFF
--- a/src/canopy/llm/cohere.py
+++ b/src/canopy/llm/cohere.py
@@ -149,7 +149,6 @@ class CohereLLM(BaseLLM):
                 message=messages.pop()['message'],
                 chat_history=messages,
                 documents=self.generate_documents_from_context(context),
-                preamble_override=None,
                 stream=stream,
                 connectors=[
                     {"id": connector} for connector in connectors

--- a/tests/system/llm/test_cohere.py
+++ b/tests/system/llm/test_cohere.py
@@ -43,7 +43,6 @@ def expected_chat_kwargs(system_prompt):
         ],
         "connectors": None,
         "documents": [],
-        "preamble_override": None,
         "stream": False,
         "max_tokens": None,
     }


### PR DESCRIPTION
## Problem

The `preamble_override` field for cohere chat completion changed to `preamble`, but we don't actually use it

## Solution

Remove the use of preamble

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Existing tests apply