### PR TITLE
update tiktoken to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [{include = "canopy", from = "src"},
 python = ">=3.9,<3.13"
 python-dotenv = "^1.0.0"
 openai = "^1.2.3"
-tiktoken = "^0.3.3"
+tiktoken = "^0.6.0"
 pydantic = "^2.0.0"
 pandas-stubs = "^2.0.3.230814"
 fastapi = ">=0.93.0, <1.0.0"


### PR DESCRIPTION
## Problem

SDK should be using the latest tiktoken dependency. If I move to tiktoken 0.3.3, then I can't use the latest langchain-openai as it requires tiktoken >=0.5.2

## Solution

rev the version. fixes #318 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Ran the tests, checked the tiktoken docs for any breaking changes since 0.3.3 (there weren't any).
