### PR TITLE
Added `source_tag='canopy'` to `knowledge_base._get_global_client()`

### DIFF
--- a/src/canopy/knowledge_base/knowledge_base.py
+++ b/src/canopy/knowledge_base/knowledge_base.py
@@ -37,7 +37,7 @@ DELETE_STARTER_CHUNKS_PER_DOC = 32
 
 @lru_cache(maxsize=1)
 def _get_global_client() -> Pinecone:
-    return Pinecone()
+    return Pinecone(source_tag="canopy")
 
 
 def list_canopy_indexes(pinecone_client: Pinecone = None) -> List[str]:


### PR DESCRIPTION
## Problem

It's not easy to quickly attribute index activity to Canopy, so we don't have a reliable way of comparing its use with other frameworks using Pinecone. 

## Solution

This adds a source_tag, 'canopy', which is inline with how our partners manage their attributions.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

1. Create a new Canopy index using the changed module.
2. Upsert one or more documents to the index.
3. Check the backend traces for the user_agent header "source_tag=canopy".
