### PR TITLE
refactor: Use Qdrant's Query API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ transformers = {version = "^4.35.2", optional = true}
 sentencepiece = "^0.1.99"
 pandas = "2.0.0"
 pyarrow = "^14.0.1"
-qdrant-client = {version = "^1.8.0", optional = true}
+qdrant-client = {version = "^1.11.1", optional = true}
 cohere = { version = "^4.37", optional = true }
 
 

--- a/src/canopy/knowledge_base/qdrant/converter.py
+++ b/src/canopy/knowledge_base/qdrant/converter.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Dict, List, Any, Union
+from typing import Dict, List, Any, Tuple, Union
 import uuid
 from canopy.knowledge_base.models import (
     KBDocChunkWithScore,
@@ -84,19 +84,14 @@ class QdrantConverter:
     @staticmethod
     def kb_query_to_search_vector(
         query: KBQuery,
-    ) -> "Union[models.NamedVector, models.NamedSparseVector]":
+    ) -> "Tuple[Union[List[float], models.SparseVector], str]":
         # Use dense vector if available, otherwise use sparse vector
-        query_vector: Union[models.NamedVector, models.NamedSparseVector]
         if query.values:
-            query_vector = models.NamedVector(name=DENSE_VECTOR_NAME, vector=query.values)  # noqa: E501
+            return query.values, DENSE_VECTOR_NAME
         elif query.sparse_values:
-            query_vector = models.NamedSparseVector(
-                name=SPARSE_VECTOR_NAME,
-                vector=models.SparseVector(
-                    indices=query.sparse_values["indices"],
-                    values=query.sparse_values["values"],
-                ),
-            )
+            return models.SparseVector(
+                indices=query.sparse_values["indices"],
+                values=query.sparse_values["values"],
+            ), SPARSE_VECTOR_NAME
         else:
             raise ValueError("Query should have either dense or sparse vector.")
-        return query_vector

--- a/src/canopy/knowledge_base/qdrant/qdrant_knowledge_base.py
+++ b/src/canopy/knowledge_base/qdrant/qdrant_knowledge_base.py
@@ -638,16 +638,17 @@ class QdrantKnowledgeBase(BaseKnowledgeBase):
 
         query_params = deepcopy(query.query_params)
 
-        query_vector = QdrantConverter.kb_query_to_search_vector(query)
+        vector, vector_name = QdrantConverter.kb_query_to_search_vector(query)
 
-        results = self._client.search(
+        results = self._client.query_points(
             self.collection_name,
-            query_vector=query_vector,
+            query=vector,
+            using=vector_name,
             limit=top_k,
             query_filter=metadata_filter,
             with_payload=True,
             **query_params,
-        )
+        ).points
 
         documents: List[KBDocChunkWithScore] = []
 

--- a/tests/system/knowledge_base/qdrant/test_config.yml
+++ b/tests/system/knowledge_base/qdrant/test_config.yml
@@ -4,6 +4,5 @@
 
 knowledge_base:
       params:
-        default_top_k: 5
         collection_name: test-config-collection
         default_top_k: 10


### PR DESCRIPTION
## Description

This PR updates the Qdrant integration to use the new [Query API](https://qdrant.tech/blog/qdrant-1.10.x/) that supersedes the search API.